### PR TITLE
Add invitation wizard skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+/node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# partys
+# Party Invitation Wizard
+
+This repository contains a minimal Laravel skeleton with an ECMAScript wizard for creating and sending event invitations. It demonstrates how to collect event details, add guests, and send email invitations.
+
+## Setup
+1. Install PHP and Composer.
+2. Run `composer install` to install Laravel dependencies.
+3. Configure your `.env` file and set up mail credentials.
+4. Serve the application using `php artisan serve`.
+
+## Usage
+Open the site in your browser. The wizard guides you through:
+1. **Event Details** – title, date and location.
+2. **Guests** – add guest email addresses.
+3. **Confirm** – review and send invitations. Emails are sent using Laravel's mailing system.
+
+This code is simplified for illustration purposes and may require additional configuration for production use.

--- a/app/Http/Controllers/InvitationController.php
+++ b/app/Http/Controllers/InvitationController.php
@@ -1,0 +1,31 @@
+<?php
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Mail;
+
+class InvitationController extends Controller
+{
+    public function wizard()
+    {
+        return view('invitations.wizard');
+    }
+
+    public function send(Request $request)
+    {
+        $data = $request->validate([
+            'event.title' => 'required|string',
+            'event.date' => 'required|date',
+            'event.location' => 'required|string',
+            'guests.*.email' => 'required|email'
+        ]);
+
+        foreach ($data['guests'] as $guest) {
+            Mail::raw("You are invited to {$data['event']['title']} at {$data['event']['location']} on {$data['event']['date']}", function ($message) use ($guest) {
+                $message->to($guest['email'])->subject('Event Invitation');
+            });
+        }
+
+        return ['status' => 'sent'];
+    }
+}

--- a/public/js/wizard.js
+++ b/public/js/wizard.js
@@ -1,0 +1,46 @@
+let step = 1;
+const event = { title: '', date: '', location: '' };
+const guests = [];
+
+document.addEventListener('DOMContentLoaded', () => {
+    const steps = document.querySelectorAll('.step');
+
+    const showStep = () => {
+        steps.forEach(s => s.style.display = s.getAttribute('data-step') == step ? 'block' : 'none');
+    };
+
+    document.querySelectorAll('.next').forEach(btn => btn.addEventListener('click', () => {
+        if (step === 1) {
+            event.title = document.getElementById('title').value;
+            event.date = document.getElementById('date').value;
+            event.location = document.getElementById('location').value;
+        }
+        if (step === 2) {
+            document.getElementById('summary').innerText = JSON.stringify({ event, guests }, null, 2);
+        }
+        step++;
+        showStep();
+    }));
+
+    document.getElementById('addGuest').addEventListener('click', () => {
+        const container = document.createElement('div');
+        const input = document.createElement('input');
+        input.type = 'email';
+        input.placeholder = 'Guest Email';
+        container.appendChild(input);
+        document.getElementById('guests').appendChild(container);
+        guests.push({ email: input.value });
+        input.addEventListener('input', () => guests[Array.from(document.getElementById('guests').children).indexOf(container)].email = input.value);
+    });
+
+    document.getElementById('send').addEventListener('click', async () => {
+        const response = await fetch('/send', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content },
+            body: JSON.stringify({ event, guests })
+        });
+        if (response.ok) alert('Invitations sent');
+    });
+
+    showStep();
+});

--- a/resources/views/invitations/wizard.blade.php
+++ b/resources/views/invitations/wizard.blade.php
@@ -1,0 +1,24 @@
+@extends('layouts.app')
+
+@section('content')
+<div id="wizard">
+    <div class="step" data-step="1">
+        <h2>Event Details</h2>
+        <input type="text" id="title" placeholder="Event Title">
+        <input type="date" id="date">
+        <input type="text" id="location" placeholder="Location">
+        <button class="next">Next</button>
+    </div>
+    <div class="step" data-step="2" style="display:none;">
+        <h2>Guests</h2>
+        <div id="guests"></div>
+        <button id="addGuest">Add Guest</button>
+        <button class="next">Next</button>
+    </div>
+    <div class="step" data-step="3" style="display:none;">
+        <h2>Confirm</h2>
+        <pre id="summary"></pre>
+        <button id="send">Send Invitations</button>
+    </div>
+</div>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta name="csrf-token" content="{{ csrf_token() }}">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Event Invitation Wizard</title>
+</head>
+<body>
+    @yield('content')
+    <script src="/js/wizard.js"></script>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,6 @@
+<?php
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\InvitationController;
+
+Route::get('/', [InvitationController::class, 'wizard']);
+Route::post('/send', [InvitationController::class, 'send']);


### PR DESCRIPTION
## Summary
- add minimal Laravel skeleton with invitation wizard
- provide ECMAScript wizard to collect event data
- document setup in README

## Testing
- `composer install` *(fails: command not found)*
- `php --version` *(fails: command not found)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684047edd62483259908a5d8087874ec